### PR TITLE
chore: upgrade Kaniko to v0.20.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --update --no-cache ca-certificates
 ##    docker build --no-cache -t vela-docker:local .    ##
 ##########################################################
 
-FROM gcr.io/kaniko-project/executor:debug-v0.19.0
+FROM gcr.io/kaniko-project/executor:debug-v0.20.0
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 


### PR DESCRIPTION
You can find a full list of release notes here:

https://github.com/GoogleContainerTools/kaniko/releases/tag/v0.20.0