### PR TITLE
chore: update kaniko to latest release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --update --no-cache ca-certificates
 ##    docker build --no-cache -t vela-docker:local .    ##
 ##########################################################
 
-FROM gcr.io/kaniko-project/executor:debug-v0.24.0
+FROM gcr.io/kaniko-project/executor:debug-v1.0.0
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 


### PR DESCRIPTION
Kaniko is release notes for v1.0.0:
https://github.com/GoogleContainerTools/kaniko/releases/tag/v1.0.0