### PR TITLE
fix(registry): skip validating user/pass with dry_run enabled

### DIFF
--- a/cmd/vela-docker/registry.go
+++ b/cmd/vela-docker/registry.go
@@ -137,23 +137,26 @@ func (r *Registry) Login() error {
 	return e.Run()
 }
 
-// Validate verifies the registry is properly configured.
+// Validate verifies the Registry is properly configured.
 func (r *Registry) Validate() error {
 	logrus.Trace("validating registry plugin configuration")
 
-	// verify password are provided
-	if len(r.Password) == 0 {
-		return fmt.Errorf("no registry password provided")
-	}
-
-	// verify url is provided
+	// verify registry is provided
 	if len(r.Name) == 0 {
 		return fmt.Errorf("no registry name provided")
 	}
 
-	// verify username is provided
-	if len(r.Username) == 0 {
-		return fmt.Errorf("no registry username provided")
+	// check if dry run is disabled
+	if !r.DryRun {
+		// check if username is provided
+		if len(r.Username) == 0 {
+			return fmt.Errorf("no registry username provided")
+		}
+
+		// check if password is provided
+		if len(r.Password) == 0 {
+			return fmt.Errorf("no registry password provided")
+		}
 	}
 
 	return nil

--- a/cmd/vela-docker/registry_test.go
+++ b/cmd/vela-docker/registry_test.go
@@ -11,59 +11,68 @@ import (
 )
 
 func TestDocker_Registry_Validate(t *testing.T) {
-	// setup types
-	r := &Registry{
-		Name:     "index.docker.io",
-		Username: "octocat",
-		Password: "superSecretPassword",
-		DryRun:   false,
+	// setup tests
+	tests := []struct {
+		failure  bool
+		registry *Registry
+	}{
+		{
+			failure: false,
+			registry: &Registry{
+				Name:     "index.docker.io",
+				Username: "octocat",
+				Password: "superSecretPassword",
+				DryRun:   false,
+			},
+		},
+		{
+			failure: false,
+			registry: &Registry{
+				Name:   "index.docker.io",
+				DryRun: true,
+			},
+		},
+		{
+			failure: true,
+			registry: &Registry{
+				Username: "octocat",
+				Password: "superSecretPassword",
+				DryRun:   false,
+			},
+		},
+		{
+			failure: true,
+			registry: &Registry{
+				Name:     "index.docker.io",
+				Password: "superSecretPassword",
+				DryRun:   false,
+			},
+		},
+		{
+			failure: true,
+			registry: &Registry{
+				Name:     "index.docker.io",
+				Username: "octocat",
+				DryRun:   false,
+			},
+		},
 	}
 
-	err := r.Validate()
-	if err != nil {
-		t.Errorf("Validate returned err: %v", err)
-	}
-}
+	// run tests
+	for _, test := range tests {
+		err := test.registry.Validate()
 
-func TestDocker_Registry_Validate_NoName(t *testing.T) {
-	// setup types
-	r := &Registry{
-		Username: "octocat",
-		Password: "superSecretPassword",
-		DryRun:   false,
-	}
+		if test.failure {
+			if err == nil {
+				t.Errorf("Validate should have returned err")
+			}
 
-	err := r.Validate()
-	if err == nil {
-		t.Errorf("Validate should have returned err")
-	}
-}
+			continue
+		}
 
-func TestDocker_Registry_Validate_NoUsername(t *testing.T) {
-	// setup types
-	r := &Registry{
-		Name:     "index.docker.io",
-		Password: "superSecretPassword",
-		DryRun:   false,
-	}
-
-	err := r.Validate()
-	if err == nil {
-		t.Errorf("Validate should have returned err")
-	}
-}
-
-func TestDocker_Registry_Validate_NoPassword(t *testing.T) {
-	// setup types
-	r := &Registry{
-		Name:     "index.docker.io",
-		Username: "octocat",
-		DryRun:   false,
-	}
-
-	err := r.Validate()
-	if err == nil {
-		t.Errorf("Validate should have returned err")
+		if err != nil {
+			t.Errorf("Validate returned err: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
Currently, if you attempt to execute the plugin with `dry_run` enabled (i.e. `dry_run: true`), you'll see the following error:

```
no registry password provided
```

This happens because we're always expecting the `username` and `password` parameters to be set.

This change will verify `dry_run` is set to `false` before validating the `username` and `password` parameters are set.

This also adds a test case to verify this new functionality as well as refactors to using table tests.