### PR TITLE
fix(registry): skip login with dry_run enabled

### DIFF
--- a/cmd/vela-docker/registry_test.go
+++ b/cmd/vela-docker/registry_test.go
@@ -10,6 +10,50 @@ import (
 	"github.com/spf13/afero"
 )
 
+func TestDocker_Registry_Login(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		failure  bool
+		registry *Registry
+	}{
+		{
+			failure: false,
+			registry: &Registry{
+				Name:     "index.docker.io",
+				Username: "octocat",
+				Password: "superSecretPassword",
+				DryRun:   true,
+			},
+		},
+		{
+			failure: true,
+			registry: &Registry{
+				Name:     "index.docker.io",
+				Username: "octocat",
+				Password: "superSecretPassword",
+				DryRun:   false,
+			},
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		err := test.registry.Login()
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("Login should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("Login returned err: %v", err)
+		}
+	}
+}
+
 func TestDocker_Registry_Validate(t *testing.T) {
 	// setup types
 	r := &Registry{


### PR DESCRIPTION
Dependent on https://github.com/go-vela/vela-docker/pull/23

Currently, if you attempt to execute the plugin with `dry_run` enabled (i.e. `dry_run: true`), you'll see the following error:

```
Error response from daemon: Get https://registry-1.docker.io/v2/: unauthorized: incorrect username or password
```

This happens because we're always trying to perform a `docker login` with the `username` and `password` parameters.

This change will verify `dry_run` is set to `false` before attempting to perform a `docker login`.

In the event `dry_run` is set to `true`, we do log a warning message:

```
dry_run enabled - skipping authentication with registry
```

This also adds table tests for the `registry.Login()` command.