### PR TITLE
fix: setting daemon configuration with flag

### DIFF
--- a/cmd/vela-docker/main.go
+++ b/cmd/vela-docker/main.go
@@ -69,6 +69,9 @@ func main() {
 	// add build flags
 	app.Flags = append(app.Flags, buildFlags...)
 
+	// add daemon flags
+	app.Flags = append(app.Flags, daemonFlags...)
+
 	// add push flags
 	app.Flags = append(app.Flags, pushFlags...)
 


### PR DESCRIPTION
Currently, if you execute the plugin inside an enterprise environment, you'll likely experience errors in regards to DNS.

Here is the Docker image we're trying to build:

```dockerfile
FROM alpine:3.12

RUN apk update

RUN apk add --no-cache curl 
```

And here is the error message we're seeing:

```

time="2021-03-31T19:32:42.727880200Z" level=info msg="No non-localhost DNS nameservers are left in resolv.conf. Using default external servers: [nameserver 8.8.8.8 nameserver 8.8.4.4]"
--
152 | time="2021-03-31T19:32:42.728645600Z" level=info msg="IPv6 enabled; Adding default IPv6 external servers: [nameserver 2001:4860:4860::8888 nameserver 2001:4860:4860::8844]"
153 | time="2021-03-31T19:32:42.740369500Z" level=info msg="No non-localhost DNS nameservers are left in resolv.conf. Using default external servers: [nameserver 8.8.8.8 nameserver 8.8.4.4]"
154 | time="2021-03-31T19:32:42.740706500Z" level=info msg="IPv6 enabled; Adding default IPv6 external servers: [nameserver 2001:4860:4860::8888 nameserver 2001:4860:4860::8844]"
155 |  
156 | #4 [2/3] RUN apk update
157 | #4 0.186 fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
158 | #4 5.192 fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
159 | #4 5.192 ERROR: http://dl-cdn.alpinelinux.org/alpine/v3.12/main: temporary error (try again later)
160 | #4 5.192 WARNING: Ignoring APKINDEX.2c4ac24e.tar.gz: No such file or directory
161 | #4 10.20 ERROR: http://dl-cdn.alpinelinux.org/alpine/v3.12/community: temporary error (try again later)
162 | #4 10.20 WARNING: Ignoring APKINDEX.40a3604f.tar.gz: No such file or directory
163 | #4 10.20 2 errors; 14 distinct packages available
164 | #4 ERROR: executor failed running [/bin/sh -c apk update]: runc did not terminate sucessfully
165 | ------
166 | > [2/3] RUN apk update:
167 | ------
168 | failed to solve with frontend dockerfile.v0: failed to build LLB: executor failed running [/bin/sh -c apk update]: runc did not terminate sucessfully
```

In order to resolve this, we need to use the `daemon` parameter provided by this plugin.

Unfortunately, our attempts to use that parameter were unsuccessful and here are the configurations we tried:

```yaml
      daemon:
        dns.servers: [ x.x.x.x, x.x.x.x ]
        dns.searches: [ x.com ]
```

```yaml
      daemon:
        dns:
          servers: [ x.x.x.x, x.x.x.x ]
          searches: [ x.com ]
```

As it turns out, the code and logic to use the `daemon` parameter is all there, but the flag itself wasn't added to the plugin.

This change adds the `daemon` parameter to the list of supported flags for the plugin.