### PR TITLE
feat(daemon): enable tuning log level

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -183,10 +183,11 @@ The following parameters are used to configure the image:
 | `bip`                 | enables specifying a network bridge IP                  | `false`  | N/A     |
 | `dns.servers`         | enables setting the DNS server to use                   | `false`  | N/A     |
 | `dns.searches`        | enables setting the DNS search domains to use           | `false`  | N/A     |
-| `experimental`        | enables experimental features                            | `false`  | N/A     |
+| `experimental`        | enables experimental features                           | `false`  | N/A     |
 | `insecure_registries` | enables insecure registry communication                 | `false`  | N/A     |
 | `ipv6`                | enables IPv6 networking                                 | `false`  | N/A     |
-| `mtu`                 | enables setting the containers network MTU               | `false`  | N/A     |
+| `log_level`           | enable setting the level of logs output by the daemon   | `false`  | `error` |
+| `mtu`                 | enables setting the containers network MTU              | `false`  | N/A     |
 | `registry_mirrors`    | enables setting a preferred Docker registry mirror      | `false`  | N/A     |
 | `storage.drivers`     | enables setting an alternate storage driver             | `false`  | N/A     |
 | `storage.opts`        | enables setting options on the alternate storage driver | `false`  | N/A     |

--- a/cmd/vela-docker/daemon.go
+++ b/cmd/vela-docker/daemon.go
@@ -30,6 +30,8 @@ type (
 		InsecureRegistries []string
 		// enables IPv6 networking
 		IPV6 bool
+		// enable setting the log level for the daemon
+		LogLevel string `json:"log_level"`
 		// enable setting the containers network MTU
 		MTU int
 		// enables setting a preferred Docker registry mirror
@@ -104,6 +106,18 @@ func (d *Daemon) Command() (*exec.Cmd, error) {
 	if d.IPV6 {
 		// add flag for Experimental from provided build command
 		flags = append(flags, "--ipv6")
+	}
+
+	// check if LogLevel is provided
+	if len(d.LogLevel) > 0 {
+		// add flag for LogLevel from provided build command
+		flags = append(flags, "--log-level", d.LogLevel)
+	} else {
+		// add flag for LogLevel hardcoded to error level logging
+		//
+		// this helps to drastically reduce the level of logs
+		// output by the plugin when starting up the docker daemon
+		flags = append(flags, "--log-level=error")
 	}
 
 	// check if MTU is provided

--- a/cmd/vela-docker/daemon.go
+++ b/cmd/vela-docker/daemon.go
@@ -94,12 +94,10 @@ func (d *Daemon) Command() (*exec.Cmd, error) {
 		flags = append(flags, "--experimental")
 	}
 
-	// check if InsecureRegistries is provided
-	if len(d.InsecureRegistries) > 0 {
-		for _, i := range d.InsecureRegistries {
-			// add flag for InsecureRegistries from provided build command
-			flags = append(flags, "--insecure-registry", i)
-		}
+	// iterate through the insecure registries provided
+	for _, i := range d.InsecureRegistries {
+		// add flag for InsecureRegistries from provided build command
+		flags = append(flags, "--insecure-registry", i)
 	}
 
 	// check if Experimental is provided
@@ -126,12 +124,10 @@ func (d *Daemon) Command() (*exec.Cmd, error) {
 		flags = append(flags, "--mtu", strconv.Itoa(d.MTU))
 	}
 
-	// check if RegistryMirrors is provided
-	if len(d.RegistryMirrors) > 0 {
-		for _, r := range d.RegistryMirrors {
-			// add flag for RegistryMirrors from provided build command
-			flags = append(flags, "--registry-mirror", r)
-		}
+	// iterate through the registry mirrors provided
+	for _, r := range d.RegistryMirrors {
+		// add flag for RegistryMirrors from provided build command
+		flags = append(flags, "--registry-mirror", r)
 	}
 
 	// add flags for Storage configuration

--- a/cmd/vela-docker/daemon.go
+++ b/cmd/vela-docker/daemon.go
@@ -115,7 +115,7 @@ func (d *Daemon) Command() (*exec.Cmd, error) {
 		//
 		// this helps to drastically reduce the level of logs
 		// output by the plugin when starting up the docker daemon
-		flags = append(flags, "--log-level=error")
+		flags = append(flags, "--log-level", "error")
 	}
 
 	// check if MTU is provided

--- a/cmd/vela-docker/daemon_test.go
+++ b/cmd/vela-docker/daemon_test.go
@@ -42,6 +42,7 @@ func TestDocker_Daemon_Command(t *testing.T) {
 		"--experimental",
 		fmt.Sprintf("--insecure-registry %s", d.InsecureRegistries[0]),
 		"--ipv6",
+		"--log-level error",
 		fmt.Sprintf("--mtu %d", d.MTU),
 		fmt.Sprintf("--registry-mirror %s", d.RegistryMirrors[0]),
 		fmt.Sprintf("--storage-driver %s", d.Storage.Driver),


### PR DESCRIPTION
This change adds a `LogLevel` field to the `Daemon{}` type:

https://github.com/go-vela/vela-docker/blob/a1dc209e0779b2d36e4386a6cb42c06ebc09f6fb/cmd/vela-docker/daemon.go#L33-L34

This will be used to set the `log-level` flag when executing the `dockerd` CLI (used to start the Docker daemon):

https://github.com/go-vela/vela-docker/blob/a1dc209e0779b2d36e4386a6cb42c06ebc09f6fb/cmd/vela-docker/daemon.go#L109-L119

You'll note that we set a fallback value of `error` for the flag passed to the command.

This will drastically reduce the amount of output the plugin produces specifically in regards to the Docker daemon starting.

In the event a end-user chooses to customize this value, they can do so with the following YAML:

```yaml
    parameters:
      daemon: 
        log_level: trace
```