### PR TITLE
enhance: fixed version output and optimized output order

### DIFF
--- a/cmd/vela-docker/daemon.go
+++ b/cmd/vela-docker/daemon.go
@@ -157,7 +157,7 @@ func (d *Daemon) Exec() error {
 
 	// iterate through with a retryLimit
 	for i := 0; i < retryLimit; i++ {
-		err := execCmd(versionCmd())
+		err := versionCmd().Run()
 		if err == nil {
 			break
 		}

--- a/cmd/vela-docker/daemon.go
+++ b/cmd/vela-docker/daemon.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os/exec"
 	"strconv"
 	"time"
@@ -140,11 +139,6 @@ func (d *Daemon) Exec() error {
 
 	// start the daemon in a thread
 	go func() {
-		// turn off daemon logs
-		// TODO make this configurable
-		cmd.Stdout = ioutil.Discard
-		cmd.Stderr = ioutil.Discard
-
 		err := execCmd(cmd)
 		if err != nil {
 			logrus.Error(err)

--- a/cmd/vela-docker/plugin.go
+++ b/cmd/vela-docker/plugin.go
@@ -32,6 +32,18 @@ func (p *Plugin) Exec() error {
 		return err
 	}
 
+	// output the docker version
+	err = execCmd(versionCmd())
+	if err != nil {
+		return err
+	}
+
+	// output the docker information
+	err = execCmd(infoCmd())
+	if err != nil {
+		return err
+	}
+
 	// create registry file for authentication
 	err = p.Registry.Write()
 	if err != nil {


### PR DESCRIPTION
This PR eliminates confusing errors and repeated output which was due to how the daemon was polled. 

Previously, the plugin used the version command to test the daemon status, which resulted in confusing output, such as below.

Previous:
```
$ /usr/local/bin/docker version
<docker version info>
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?

$ /usr/local/bin/docker version
<docker version info>
```

Now:
```
$ /usr/local/bin/docker version
<docker version info>
```