### PR TITLE
chore(actions): fix actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.18
+    
     steps:
     - name: clone
       uses: actions/checkout@v3
+
+    - name: install go
+      uses: actions/setup-go@v3
+      with:
+        # use version from go.mod file
+        go-version-file: 'go.mod'
+        cache: true
 
     - name: build
       run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,14 +11,18 @@ on:
 jobs:
   prerelease:
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.18
+    
     steps:
     - name: clone
       uses: actions/checkout@v3
       with:
         # ensures we fetch tag history for the repository
         fetch-depth: 0
+
+    - name: install go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18
 
     - name: setup
       run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -22,7 +22,9 @@ jobs:
     - name: install go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        # use version from go.mod file
+        go-version-file: 'go.mod'
+        cache: true
 
     - name: setup
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,14 +10,18 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.18
+
     steps:
     - name: clone
       uses: actions/checkout@v3
       with:
         # ensures we fetch tag history for the repository
         fetch-depth: 0
+
+    - name: install go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18
 
     - name: build
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,9 @@ jobs:
     - name: install go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        # use version from go.mod file
+        go-version-file: 'go.mod'
+        cache: true
 
     - name: build
       env:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -9,11 +9,17 @@ on:
 jobs:
   diff-review:
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.18
+    
     steps:
     - name: clone
       uses: actions/checkout@v3
+
+    - name: install go
+      uses: actions/setup-go@v3
+      with:
+        # use version from go.mod file
+        go-version-file: 'go.mod'
+        cache: true
 
     - name: golangci-lint
       uses: reviewdog/action-golangci-lint@v2
@@ -26,11 +32,17 @@ jobs:
 
   full-review:
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.18
+    
     steps:
     - name: clone
       uses: actions/checkout@v3
+
+    - name: install go
+      uses: actions/setup-go@v3
+      with:
+        # use version from go.mod file
+        go-version-file: 'go.mod'
+        cache: true
 
     - name: golangci-lint
       uses: reviewdog/action-golangci-lint@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.18
+    
     steps:
     - name: clone
       uses: actions/checkout@v3
+
+    - name: install go
+      uses: actions/setup-go@v3
+      with:
+        # use version from go.mod file
+        go-version-file: 'go.mod'
+        cache: true
 
     - name: test
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,11 +10,17 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.18
+    
     steps:
     - name: clone
       uses: actions/checkout@v3
+
+    - name: install go
+      uses: actions/setup-go@v3
+      with:
+        # use version from go.mod file
+        go-version-file: 'go.mod'
+        cache: true
 
     - name: validate
       run: |


### PR DESCRIPTION
appears that the new version of the publish action (elgohr/Publish-Docker-Github-Action@v4) is not able to run in a container - see https://github.com/go-vela/vela-docker/runs/7885445695?check_suite_focus=true. 

this modifies all jobs to install Go using https://github.com/actions/setup-go utilizing caching and version info from go.mod file.